### PR TITLE
Handle systems without getprotobyname()

### DIFF
--- a/lib/POE/Component/Client/Ping.pm
+++ b/lib/POE/Component/Client/Ping.pm
@@ -164,8 +164,7 @@ sub _create_handle {
   my ($kernel, $heap) = @_;
   DEBUG_SOCKET and warn "opening a raw socket for icmp";
 
-  my $protocol = (getprotobyname('icmp'))[2]
-    or die "can't get icmp protocol by name: $!";
+  my $protocol = Socket::IPPROTO_ICMP;
 
   my $socket = gensym();
   socket($socket, PF_INET, SOCK_RAW, $protocol)

--- a/t/03_provided_socket.t
+++ b/t/03_provided_socket.t
@@ -124,8 +124,7 @@ sub client_stop {
 use Symbol qw(gensym);
 use Socket;
 
-my $protocol = (getprotobyname('icmp'))[2]
-  or die "can't get icmp protocol by name: $!";
+my $protocol = Socket::IPPROTO_ICMP;
 
 my $socket = gensym();
 socket($socket, PF_INET, SOCK_RAW, $protocol)


### PR DESCRIPTION
As before, this is really for Android.
