### PR TITLE
Don't output raw bytes during debugging

### DIFF
--- a/lib/POE/Component/Client/Ping.pm
+++ b/lib/POE/Component/Client/Ping.pm
@@ -615,7 +615,7 @@ sub poco_ping_pong {
     warn ",----- packet from ", inet_ntoa($from_ip), ", port $from_port\n";
     warn "| type = $from_type / subtype = $from_subcode\n";
     warn "| checksum = $from_checksum, pid = $from_pid, seq = $from_seq\n";
-    warn "| message: $from_message\n";
+    warn "| message: ", unpack("H*", $from_message), "\n";
     warn "`------------------------------------------------------------\n";
   };
 


### PR DESCRIPTION
Howdy, I was assigned your module for the Sept. Pull Request Challenge (http://cpan-prc.org/).

This is a pretty small change, but will keep the output from messing up a terminal when running the module with debugging enabled, which should make it a tiny bit easier for people to debug their network and/or this module.
